### PR TITLE
alphabetize the ldap attributes

### DIFF
--- a/templates/default/authentication.yml.erb
+++ b/templates/default/authentication.yml.erb
@@ -18,8 +18,8 @@ production:
       <% end %>
 
       attribute_mapping:
-      <% node[:gitorious][:ldap][:attribute_mapping].each do |key, value| %>
-        <%= key %>: <%= value %>
+      <% node[:gitorious][:ldap][:attribute_mapping].keys.sort.each do |key| %>
+        <%= key %>: <%= node[:gitorious][:ldap][:attribute_mapping][key] %>
       <% end %>
 
       encryption: <%= node[:gitorious][:ldap][:encryption] %>


### PR DESCRIPTION
For multiple attributes, iterating directly through the hash is randomly ordered. This causes slow/disruptive restarts for the four services that watch this template. Thus, alpha-order the attribute keys.
