### PR TITLE
Switch to configured git user

### DIFF
--- a/templates/default/git-daemon.erb
+++ b/templates/default/git-daemon.erb
@@ -35,7 +35,7 @@ start()
   do_check_pid
   if [ $RUNNING != 2 ] ; then
     echo -n "Starting $PROG"
-    /bin/su - git -c "$GIT_DAEMON" 2>/dev/null
+    /bin/su - <%= @node[:gitorious][:user] %> -c "$GIT_DAEMON" 2>/dev/null
     sleep 1
     if [ -f $PID_FILE ] ; then
       echo "."

--- a/templates/default/git-poller.erb
+++ b/templates/default/git-poller.erb
@@ -39,7 +39,7 @@ start()
   do_check_pid
   if [ $RUNNING != 2 ] ; then
     echo -n "Starting $PROG"
-    /bin/su - git -c "RAILS_ENV=$RAILS_ENV $GIT_POLLER start" 2>/dev/null
+    /bin/su - <%= @node[:gitorious][:user] %> -c "RAILS_ENV=$RAILS_ENV $GIT_POLLER start" 2>/dev/null
     sleep 4 
     if [ -f $PID_FILE ] ; then
       echo "."
@@ -64,7 +64,7 @@ stop()
   else
     echo -n "Stopping $PROG"
     #killproc -p $PID_FILE
-    /bin/su - git -c "RAILS_ENV=$RAILS_ENV $GIT_POLLER stop" 1>/dev/null 2>/dev/null
+    /bin/su - <%= @node[:gitorious][:user] %> -c "RAILS_ENV=$RAILS_ENV $GIT_POLLER stop" 1>/dev/null 2>/dev/null
     RETVAL=$?
     sleep 1
     # if we are in halt or reboot runlevel kill all running sessions

--- a/templates/default/git-thinking-sphinx.erb
+++ b/templates/default/git-thinking-sphinx.erb
@@ -23,15 +23,15 @@ PID_FILE=$GITORIOUS_HOME/db/sphinx/log/searchd.pid
 case "$1" in
   start)
     echo -n "Starting git-thinking-sphinx"
-    /bin/su - git -c "$START_CMD" 1>/dev/null 2>/dev/null && echo "." || echo ": FAILURE (already running?)"
+    /bin/su - <%= @node[:gitorious][:user] %> -c "$START_CMD" 1>/dev/null 2>/dev/null && echo "." || echo ": FAILURE (already running?)"
     ;;
   stop)
     echo -n "Stopping git-thinking-sphinx"
-    /bin/su - git -c "$STOP_CMD" 1>/dev/null 2>/dev/null && echo "." || echo ": FAILURE (maybe not running?)"
+    /bin/su - <%= @node[:gitorious][:user] %> -c "$STOP_CMD" 1>/dev/null 2>/dev/null && echo "." || echo ": FAILURE (maybe not running?)"
     ;;
   restart)
     echo -n "Restarting git-thinking-sphinx"
-    /bin/su - git -c "$RESTART_CMD" 1>/dev/null && echo "."  || echo ": FAILURE"
+    /bin/su - <%= @node[:gitorious][:user] %> -c "$RESTART_CMD" 1>/dev/null && echo "."  || echo ": FAILURE"
     ;;
   *)
     echo $"Usage: $0 {start|stop|restart}"


### PR DESCRIPTION
The git daemons were configured statically with user "git". When
node[:gitorious][:user] was configured as a _different_ user, these
daemons would thus fail.
