### PR TITLE
Convert SSL paths to attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Attribute | Description | Default
 `ldap:distinguished_name_template` | | `nil` (defaults to `$LOGIN_ATTRIBUTE={},$BASE_DN`)
 `ldap:attribute_mapping` | | `{'displayName' => 'fullname', 'mail' => 'email'}`
 `ldap:encryption`        | | `simple_tls`
+`apache:ssl:cert_path`   | Location of Apache SSL certificate | `/etc/ssl/certs/ssl-cert-snakeoil.pem`
+`apache:ssl:key_path`    | Location of Apache SSL key | `/etc/ssl/private/ssl-cert-snakeoil.key`
 
 Usage
 =====

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,4 +26,5 @@ default[:gitorious][:ldap][:attribute_mapping] = {
 }
 default[:gitorious][:ldap][:encryption] = 'simple_tls'
 
-
+default[:gitorious][:apache][:ssl][:cert_path] = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+default[:gitorious][:apache][:ssl][:key_path] = '/etc/ssl/private/ssl-cert-snakeoil.key'

--- a/templates/default/gitorious-ssl.erb
+++ b/templates/default/gitorious-ssl.erb
@@ -2,8 +2,8 @@
   <VirtualHost _default_:443>
     DocumentRoot <%= @gitorious_path %>/public
     SSLEngine on
-    SSLCertificateFile    /etc/ssl/certs/ssl-cert-snakeoil.pem  
-    SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+    SSLCertificateFile    <%= @node[:gitorious][:apache][:ssl][:cert_path] %>
+    SSLCertificateKeyFile <%= @node[:gitorious][:apache][:ssl][:key_path] %>
     BrowserMatch ".*MSIE.*" nokeepalive ssl-unclean-shutdown downgrade-1.0 force-response-1.0
   </VirtualHost>
 </IfModule>


### PR DESCRIPTION
Normally SSL sites will want to use their own, valid SSL certificate and
key, instead of using the self-signed "snake-oil" certificate. Configure
the path to the key and certificate in gitorious cookbook attributes.
