### PR TITLE
Fix non-ldap authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Attribute | Description | Default
 `custom_username_label` | Used on the login page | `Username`
 `mysql_database`      | Mysql database name | `gitorious`
 `mysql_password`      | Mysql user password | `1234`
-`use_ldap_for_authorization` | | `true`
+`use_ldap_for_authorization` | If this is set to false, all other ldap attributes are ignored | `true`
 `ldap:host`           | | `ldap.gitorious.org`
 `ldap:port`           | | `389`
 `ldap:base_dn`        | | `DC=gitorious,DC=org`

--- a/templates/default/authentication.yml.erb
+++ b/templates/default/authentication.yml.erb
@@ -1,5 +1,6 @@
 production:
   disable_default: false
+<% if node[:gitorious][:use_ldap_for_authorization] %>
   methods:
     - adapter: Gitorious::Authentication::LDAPAuthentication
 
@@ -51,3 +52,4 @@ production:
       # of group lookups. Enter how many minutes these results should
       # be cached, default is 0 (no caching)
       #cache_expiry: 60
+<% end %>


### PR DESCRIPTION
If attribute `use_ldap_for_authorization` was set to false, gitorious
would still attempt to authorize using the configured LDAP parameters.
Fix this, and add note in the documentation.
