### PR TITLE
Imagemagick not installing on ubuntu 12.04.3 & recipe not being cloned properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Dependencies
 * `mysql`
 * `database` (for the `mysql` providers)
 * `memcached`
+* `imagemagick`
 
 Attributes
 ==========

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ depends          "passenger_apache2"
 depends          "mysql"
 depends          "database"
 depends          "memcached"
+depends          "imagemagick"
 
 %w(centos redhat ubuntu debian).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -70,7 +70,7 @@ end
   end
 end
 
-package "ImageMagick"
+include_recipe "imagemagick"
 gem_package "bundler"
 
 # Install gitorious mainline

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -53,6 +53,14 @@ directory deploy_path do
   recursive true
 end
 
+git deploy_path do
+  repository node[:gitorious][:git][:url]
+  reference node[:gitorious][:git][:ref]
+  user gitorious_user
+  enable_submodules true
+  action :checkout
+end
+
 directory "#{deploy_path}/.ssh" do
   owner gitorious_user
   mode "700"
@@ -74,14 +82,6 @@ include_recipe "imagemagick"
 gem_package "bundler"
 
 # Install gitorious mainline
-
-git deploy_path do
-  repository node[:gitorious][:git][:url]
-  reference node[:gitorious][:git][:ref]
-  user gitorious_user
-  enable_submodules true
-  action :checkout
-end
 
 directory "#{deploy_path}/tmp/pids" do
   owner gitorious_user


### PR DESCRIPTION
This pull request fixes 2 issues I ran into while attempting to run this recipe. At first I found that I was receiving an error with imagemagick and set up the recipe to use the opscode imagemagick recipe instead. After I fixed that, I found that the recipe was skipping right over pulling down gitorious into /var/www/gitorious because the directory already contained .ssh and another directory at that point, so I moved the clone to happen earlier in the code.
